### PR TITLE
Simulate finite non-zero shots in the simulators...

### DIFF
--- a/pennylane_pq/devices.py
+++ b/pennylane_pq/devices.py
@@ -48,6 +48,7 @@ ProjectQClassicalSimulator
 
 """
 import abc
+import numpy as np
 import projectq as pq
 from projectq.ops import (HGate, XGate, YGate, ZGate, SGate, TGate, SqrtXGate,
                           SwapGate, Rx, Ry, Rz, R, SqrtSwapGate)
@@ -328,6 +329,11 @@ class ProjectQSimulator(_ProjectQDevice):
         #         pq.ops.QubitOperator("Z"+'0'), [qubit])
         #                for qubit in self.reg]
         #     variance = [1 - e**2 for e in expval]
+
+        if self.shots != 0:
+            p0 = (expval+1)/2
+            n0 = np.random.binomial(self.shots, p0)
+            expval = (n0 - (self.shots-n0)) / self.shots
 
         return expval
 

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -43,6 +43,7 @@ class CompareWithDefaultQubitTest(BaseTest):
         self.devices = [DefaultQubit(wires=self.num_subsystems)]
         if self.args.device == 'simulator' or self.args.device == 'all':
             self.devices.append(ProjectQSimulator(wires=self.num_subsystems))
+            self.devices.append(ProjectQSimulator(wires=self.num_subsystems, shots=20000000))
         if self.args.device == 'ibm' or self.args.device == 'all':
             ibm_options = pennylane.default_config['projectq.ibm']
             if "user" in ibm_options and "password" in ibm_options:
@@ -131,7 +132,7 @@ class CompareWithDefaultQubitTest(BaseTest):
                         if (operation, observable) not in outputs:
                             outputs[(operation, observable)] = {}
 
-                        outputs[(operation, observable)][type(dev)] = output
+                        outputs[(operation, observable)][str(type(dev).__name__)+"(shots="+str(dev.shots)+")"] = output
 
                     except IgnoreOperationException as e:
                         log.info(e)
@@ -139,7 +140,7 @@ class CompareWithDefaultQubitTest(BaseTest):
         #if we could run the circuit on more than one device assert that both should have given the same output
         for (key,val) in outputs.items():
             if len(val) >= 2:
-                self.assertAllElementsAlmostEqual(val.values(), delta=self.tol, msg="Outputs "+str(list(val.values()))+" of devices "+str(list(val.keys()))+" do not agree for a circuit consisting of a "+str(key[0])+" Operation followed by a "+str(key[0])+" Expectation." )
+                self.assertAllElementsAlmostEqual(val.values(), delta=self.tol, msg="Outputs "+str(list(val.values()))+" of devices "+str(list(val.keys()))+" with corresponding shots="+str(dev.shots for dev in val)+" do not agree for a circuit consisting of a "+str(key[0])+" Operation followed by a "+str(key[0])+" Expectation." )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
...in the same way the default.qubit plugin does that.

**Description of the Change:**

Even the simulator backend now outputs "noisy" expectation value if `shots!=0`

**Benefits:**

More realistic simulation.

**Possible Drawbacks:**

With current implementation tests only pass with high probability. I will fix that by fixing the seed.

**Related GitHub Issues:**
https://github.com/XanaduAI/pennylane/issues/106