### PR TITLE
More measurements

### DIFF
--- a/pennylane_pq/devices.py
+++ b/pennylane_pq/devices.py
@@ -469,7 +469,7 @@ class ProjectQIBMBackend(_ProjectQDevice):
                 self.apply('S', e.wires, list())
                 self.apply('Hadamard', e.wires, list())
             elif e.name == 'Hadamard':
-                self.apply('RotY', e.wires, list(- np.pi/4))
+                self.apply('RY', e.wires, [-np.pi/4])
             elif e.name == 'Hermitian':
                 raise NotImplementedError
 

--- a/pennylane_pq/devices.py
+++ b/pennylane_pq/devices.py
@@ -263,7 +263,6 @@ class ProjectQSimulator(_ProjectQDevice):
       :class:`pennylane.RY`,
       :class:`pennylane.RZ`,
       :class:`pennylane.PhaseShift`,
-      :class:`pennylane.QubitStateVector`,
       :class:`pennylane.Hadamard`,
       :class:`pennylane.Rot`,
       :class:`pennylane.QubitUnitary`,
@@ -282,12 +281,6 @@ class ProjectQSimulator(_ProjectQDevice):
       :class:`pennylane_pq.T <pennylane_pq.ops.T>`,
       :class:`pennylane_pq.SqrtX <pennylane_pq.ops.SqrtX>`,
       :class:`pennylane_pq.SqrtSwap <pennylane_pq.ops.SqrtSwap>`
-
-    ..
-       :class:`pennylane_pq.AllPauliZ <pennylane_pq.ops.AllPauliZ>`
-
-       Extra Expectations:
-         :class:`pennylane_pq.expval.AllPauliZ`
 
     """
 
@@ -394,7 +387,6 @@ class ProjectQIBMBackend(_ProjectQDevice):
       :class:`pennylane.RY`,
       :class:`pennylane.RZ`,
       :class:`pennylane.PhaseShift`,
-      :class:`pennylane.QubitStateVector`,
       :class:`pennylane.Hadamard`,
       :class:`pennylane.Rot`,
       :class:`pennylane.BasisState`
@@ -421,17 +413,12 @@ class ProjectQIBMBackend(_ProjectQDevice):
       :class:`pennylane_pq.SqrtX <pennylane_pq.ops.SqrtX>`,
       :class:`pennylane_pq.SqrtSwap <pennylane_pq.ops.SqrtSwap>`,
 
-    ..
-       :class:`pennylane_pq.AllPauliZ <pennylane_pq.ops.AllPauliZ>`
-
-       Extra Expectations:
-         :class:`pennylane_pq.expval.AllPauliZ`
     """
 
     short_name = 'projectq.ibm'
     _operation_map = {key:val for key, val in PROJECTQ_OPERATION_MAP.items()
                       if val in [HGate, XGate, YGate, ZGate, SGate, TGate,
-                                 SqrtXGate, SwapGate, Rx, Ry, Rz, R, CNOT,
+                                 SqrtXGate, SwapGate, SqrtSwapGate, Rx, Ry, Rz, R, CNOT,
                                  CZ, Rot, BasisState]}
     _expectation_map = dict({key:val for key, val in _operation_map.items() if val in [HGate, XGate, YGate, ZGate]}, **{'Identity': None})
     _circuits = {}
@@ -522,12 +509,6 @@ class ProjectQClassicalSimulator(_ProjectQDevice):
       :class:`pennylane.expval.PauliZ`,
       :class:`pennylane.expval.Identity`
 
-    ..
-       Extra Operations:
-         :class:`pennylane_pq.AllPauliZ <pennylane_pq.ops.AllPauliZ>`
-
-       Extra Expectations:
-         :class:`pennylane_pq.expval.AllPauliZ`
     """
 
     short_name = 'projectq.classical'

--- a/pennylane_pq/devices.py
+++ b/pennylane_pq/devices.py
@@ -336,7 +336,7 @@ class ProjectQSimulator(_ProjectQDevice):
         #                for qubit in self.reg]
         #     variance = [1 - e**2 for e in expval]
 
-        if self.shots != 0:
+        if self.shots != 0 and expectation != 'Identity':
             p0 = (expval+1)/2
             n0 = np.random.binomial(self.shots, p0)
             expval = (n0 - (self.shots-n0)) / self.shots

--- a/pennylane_pq/devices.py
+++ b/pennylane_pq/devices.py
@@ -318,11 +318,14 @@ class ProjectQSimulator(_ProjectQDevice):
         """Retrieve the requested expectation value.
         """
         if expectation == 'PauliX' or expectation == 'PauliY' or expectation == 'PauliZ':
-            wire = wires[0]
-
             expval = self.eng.backend.get_expectation_value(
                 pq.ops.QubitOperator(str(expectation)[-1]+'0'),
-                [self.reg[wire]])
+                [self.reg[wires[0]]])
+            # variance = 1 - expval**2
+        elif expectation == 'Hadamard':
+            expval = self.eng.backend.get_expectation_value(
+                1/np.sqrt(2)*pq.ops.QubitOperator('X0')+1/np.sqrt(2)*pq.ops.QubitOperator('Z0'),
+                [self.reg[wires[0]]])
             # variance = 1 - expval**2
         elif expectation == 'Identity':
             expval = 1

--- a/pennylane_pq/devices.py
+++ b/pennylane_pq/devices.py
@@ -465,11 +465,13 @@ class ProjectQIBMBackend(_ProjectQDevice):
             if e.name == 'PauliX':
                 self.apply('Hadamard', e.wires, list())
             elif e.name == 'PauliY':
-                pass
+                self.apply('PauliZ', e.wires, list())
+                self.apply('S', e.wires, list())
+                self.apply('Hadamard', e.wires, list())
             elif e.name == 'Hadamard':
-                pass
+                self.apply('RotY', e.wires, list(- np.pi/4))
             elif e.name == 'Hermitian':
-                pass
+                raise NotImplementedError
 
         pq.ops.All(pq.ops.Measure) | self.reg #pylint: disable=expression-not-assigned
         self.eng.flush()
@@ -479,19 +481,11 @@ class ProjectQIBMBackend(_ProjectQDevice):
         """
         probabilities = self.eng.backend.get_probabilities(self.reg)
 
-        if expectation == 'PauliZ':
-            wire = wires[0]
-
-            expval = (1-(2*sum(p for (state, p) in probabilities.items() if state[wire] == '1'))-(1-2*sum(p for (state, p) in probabilities.items() if state[wire] == '0')))/2
+        if expectation == 'PauliX' or expectation == 'PauliY' or expectation == 'PauliZ' or expectation == 'Hadamard':
+            expval = (1-(2*sum(p for (state, p) in probabilities.items() if state[wires[0]] == '1'))-(1-2*sum(p for (state, p) in probabilities.items() if state[wires[0]] == '0')))/2
             #variance = 1 - ev**2
-        elif expectation == 'PauliX':
-            pass
-        elif expectation == 'PauliY':
-            pass
-        elif expectation == 'Hadamard':
-            pass
         elif expectation == 'Hermitian':
-            pass
+            raise NotImplementedError
         elif expectation == 'Identity':
             expval = sum(p for (state, p) in probabilities.items())
             # variance = 1 - expval**2

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -136,7 +136,7 @@ class CompareWithDefaultQubitTest(BaseTest):
         #if we could run the circuit on more than one device assert that both should have given the same output
         for (key,val) in outputs.items():
             if len(val) >= 2:
-                self.assertAllElementsAlmostEqual(val.values(), delta=self.tol, msg="Outputs "+str(list(val.values()))+" of devices "+str(list(val.keys()))+" with corresponding shots="+str(dev.shots for dev in val)+" do not agree for a circuit consisting of a "+str(key[0])+" Operation followed by a "+str(key[0])+" Expectation." )
+                self.assertAllElementsAlmostEqual(val.values(), delta=self.tol, msg="Outputs "+str(list(val.values()))+" of devices "+str(list(val.keys()))+" with corresponding shots="+str(dev.shots for dev in val)+" do not agree for a circuit consisting of a "+str(key[0])+" Operation followed by a "+str(key[1])+" Expectation." )
 
 
 if __name__ == '__main__':

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,129 @@
+# Copyright 2018 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for the :mod:`pennylane_pq` device documentation
+"""
+
+import unittest
+import logging as log
+import re
+from pkg_resources import iter_entry_points
+from defaults import pennylane as qml, BaseTest
+import pennylane
+from pennylane import Device, DeviceError
+from pennylane import numpy as np
+import pennylane_pq
+import pennylane_pq.expval
+from pennylane_pq.devices import ProjectQSimulator, ProjectQClassicalSimulator, ProjectQIBMBackend
+
+log.getLogger('defaults')
+
+class DocumentationTest(BaseTest):
+    """test documentation of the plugin.
+    """
+
+    num_subsystems = 4
+    devices = None
+
+    devices = None
+    def setUp(self):
+        super().setUp()
+
+        self.devices = []
+        if self.args.device == 'simulator' or self.args.device == 'all':
+            self.devices.append(ProjectQSimulator(wires=self.num_subsystems))
+            self.devices.append(ProjectQSimulator(wires=self.num_subsystems, shots=20000000))
+        if self.args.device == 'ibm' or self.args.device == 'all':
+            ibm_options = pennylane.default_config['projectq.ibm']
+            if "user" in ibm_options and "password" in ibm_options:
+                self.devices.append(ProjectQIBMBackend(wires=self.num_subsystems, use_hardware=False, num_runs=8*1024, user=ibm_options['user'], password=ibm_options['password']))
+            else:
+                log.warning("Skipping test of the ProjectQIBMBackend device because IBM login credentials could not be found in the PennyLane configuration file.")
+        if self.args.device == 'classical' or self.args.device == 'all':
+            self.devices.append(ProjectQClassicalSimulator(wires=self.num_subsystems))
+
+    def test_device_docstrings(self):
+        for dev in self.devices:
+            docstring = dev.__doc__
+            supp_operations = dev.operations
+            supp_expectations = dev.expectations
+            #print(docstring)
+            documented_operations = ([ re.findall(r"(?:pennylane\.|pennylane_pq.ops\.)([^`> ]*)", string) for string in re.findall(r"(?:(?:Extra|Supported PennyLane) Operations:\n((?:\s*:class:`[^`]+`,?\n)*))", docstring, re.MULTILINE)])
+            documented_operations = set([item for sublist in documented_operations for item in sublist])
+
+            documented_expectations = ([ re.findall(r"(?:pennylane\.expval\.|pennylane_pq\.expval\.)([^`> ]*)", string) for string in re.findall(r"(?:(?:Extra|Supported PennyLane) Expectations:\n((?:\s*:class:`[^`]+`,?\n)*))", docstring, re.MULTILINE)])
+            documented_expectations = set([item for sublist in documented_expectations for item in sublist])
+
+            supported_but_not_documented_operations = supp_operations.difference(documented_operations)
+            self.assertFalse(supported_but_not_documented_operations, msg="For device "+dev.short_name+" the Operations "+str(supported_but_not_documented_operations)+" are supported but not documented.")
+            documented_but_not_supported_operations = documented_operations.difference(supp_operations)
+            self.assertFalse(documented_but_not_supported_operations, msg="For device "+dev.short_name+" the Operations "+str(documented_but_not_supported_operations)+" are documented but not actually supported.")
+
+            supported_but_not_documented_expectations = supp_expectations.difference(documented_expectations)
+            self.assertFalse(supported_but_not_documented_expectations, msg="For device "+dev.short_name+" the Expectations "+str(supported_but_not_documented_expectations)+" are supported but not documented.")
+            documented_but_not_supported_expectations = documented_expectations.difference(supp_expectations)
+            self.assertFalse(documented_but_not_supported_expectations, msg="For device "+dev.short_name+" the Expectations "+str(documented_but_not_supported_expectations)+" are documented but not actually supported.")
+
+
+
+
+
+    # def test_ibm_no_user(self):
+    #     if self.args.device == 'ibm' or self.args.device == 'all':
+    #         self.assertRaises(ValueError, ProjectQIBMBackend, wires=self.num_subsystems, use_hardware=False, password='password')
+
+    # def test_ibm_no_password(self):
+    #     if self.args.device == 'ibm' or self.args.device == 'all':
+    #         self.assertRaises(ValueError, ProjectQIBMBackend, wires=self.num_subsystems, use_hardware=False, user='user')
+
+    # def test_log_verbose(self):
+    #     dev = ProjectQIBMBackend(wires=self.num_subsystems, log=True, use_hardware=False, user="user", password='password')
+    #     self.assertEqual(dev.kwargs['log'],True)
+    #     self.assertEqual(dev.kwargs['log'],dev.kwargs['verbose'])
+
+    # def test_shots(self):
+    #     if self.args.device == 'ibm' or self.args.device == 'all':
+    #         shots = 5
+    #         dev1 = ProjectQIBMBackend(wires=self.num_subsystems, shots=shots, use_hardware=False, user="user", password='password')
+    #         self.assertEqual(shots, dev1.shots)
+    #         self.assertEqual(shots, dev1.kwargs['num_runs'])
+
+    #         dev2 = ProjectQIBMBackend(wires=self.num_subsystems, num_runs=shots, use_hardware=False, user="user", password='password')
+    #         self.assertEqual(shots, dev2.shots)
+    #         self.assertEqual(shots, dev2.kwargs['num_runs'])
+
+    #         dev2 = ProjectQIBMBackend(wires=self.num_subsystems, shots=shots+2, num_runs=shots, use_hardware=False, user="user", password='password')
+    #         self.assertEqual(shots, dev2.shots)
+    #         self.assertEqual(shots, dev2.kwargs['num_runs'])
+
+    # def test_initiatlization_via_pennylane(self):
+    #     for short_name in [
+    #             'projectq.simulator',
+    #             'projectq.classical',
+    #             'projectq.ibm'
+    #     ]:
+    #         try:
+    #             dev = dev = qml.device(short_name, wires=2, user='user', password='password')
+    #         except DeviceError:
+    #             raise Exception("This test is expected to fail until pennylane-pq is installed.")
+
+if __name__ == '__main__':
+    print('Testing PennyLane ProjectQ Plugin version ' + qml.version() + ', device initialization.')
+    # run the tests in this file
+    suite = unittest.TestSuite()
+    for t in (DocumentationTest, ):
+        ttt = unittest.TestLoader().loadTestsFromTestCase(t)
+        suite.addTests(ttt)
+
+    unittest.TextTestRunner().run(suite)

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -49,7 +49,7 @@ class DocumentationTest(BaseTest):
             if "user" in ibm_options and "password" in ibm_options:
                 self.devices.append(ProjectQIBMBackend(wires=self.num_subsystems, use_hardware=False, num_runs=8*1024, user=ibm_options['user'], password=ibm_options['password']))
             else:
-                log.warning("Skipping test of the ProjectQIBMBackend device because IBM login credentials could not be found in the PennyLane configuration file.")
+                self.devices.append(ProjectQIBMBackend(wires=self.num_subsystems, use_hardware=False, num_runs=8*1024, user='user', password='password'))
         if self.args.device == 'classical' or self.args.device == 'all':
             self.devices.append(ProjectQClassicalSimulator(wires=self.num_subsystems))
 
@@ -76,50 +76,8 @@ class DocumentationTest(BaseTest):
             self.assertFalse(documented_but_not_supported_expectations, msg="For device "+dev.short_name+" the Expectations "+str(documented_but_not_supported_expectations)+" are documented but not actually supported.")
 
 
-
-
-
-    # def test_ibm_no_user(self):
-    #     if self.args.device == 'ibm' or self.args.device == 'all':
-    #         self.assertRaises(ValueError, ProjectQIBMBackend, wires=self.num_subsystems, use_hardware=False, password='password')
-
-    # def test_ibm_no_password(self):
-    #     if self.args.device == 'ibm' or self.args.device == 'all':
-    #         self.assertRaises(ValueError, ProjectQIBMBackend, wires=self.num_subsystems, use_hardware=False, user='user')
-
-    # def test_log_verbose(self):
-    #     dev = ProjectQIBMBackend(wires=self.num_subsystems, log=True, use_hardware=False, user="user", password='password')
-    #     self.assertEqual(dev.kwargs['log'],True)
-    #     self.assertEqual(dev.kwargs['log'],dev.kwargs['verbose'])
-
-    # def test_shots(self):
-    #     if self.args.device == 'ibm' or self.args.device == 'all':
-    #         shots = 5
-    #         dev1 = ProjectQIBMBackend(wires=self.num_subsystems, shots=shots, use_hardware=False, user="user", password='password')
-    #         self.assertEqual(shots, dev1.shots)
-    #         self.assertEqual(shots, dev1.kwargs['num_runs'])
-
-    #         dev2 = ProjectQIBMBackend(wires=self.num_subsystems, num_runs=shots, use_hardware=False, user="user", password='password')
-    #         self.assertEqual(shots, dev2.shots)
-    #         self.assertEqual(shots, dev2.kwargs['num_runs'])
-
-    #         dev2 = ProjectQIBMBackend(wires=self.num_subsystems, shots=shots+2, num_runs=shots, use_hardware=False, user="user", password='password')
-    #         self.assertEqual(shots, dev2.shots)
-    #         self.assertEqual(shots, dev2.kwargs['num_runs'])
-
-    # def test_initiatlization_via_pennylane(self):
-    #     for short_name in [
-    #             'projectq.simulator',
-    #             'projectq.classical',
-    #             'projectq.ibm'
-    #     ]:
-    #         try:
-    #             dev = dev = qml.device(short_name, wires=2, user='user', password='password')
-    #         except DeviceError:
-    #             raise Exception("This test is expected to fail until pennylane-pq is installed.")
-
 if __name__ == '__main__':
-    print('Testing PennyLane ProjectQ Plugin version ' + qml.version() + ', device initialization.')
+    print('Testing PennyLane ProjectQ Plugin version ' + qml.version() + ', device documentation.')
     # run the tests in this file
     suite = unittest.TestSuite()
     for t in (DocumentationTest, ):


### PR DESCRIPTION
**Description of the Change:**

* Increases the number of supported measurements on the IBM backend by automatically applying operations before the the final measurement (which is always in the PauliZ basis)

* Fixes inconsistencies between the documented and actually implemented operations and adds a unit test to make sure they stay in sync form now on.

* Adds unit test of parts of the IBM backend based that uses mocking to allow it to run without login credentials. 
 
**Benefits:**
* Unlocks more measurements
* Improves and corrects docs
* Increases test coverage

**Possible Drawbacks:**
none
**Related GitHub Issues:**
none