### PR TITLE
Fix potential binomial distribution <0 or >1 edge case

### DIFF
--- a/pennylane_pq/devices.py
+++ b/pennylane_pq/devices.py
@@ -338,10 +338,7 @@ class ProjectQSimulator(_ProjectQDevice):
 
         if self.shots != 0 and expectation != 'Identity':
             p0 = (expval+1)/2
-            if p0 < 0:
-                p0 = 0
-            if p0 > 1:
-                p0 = 1
+            p0 = max(min(p0, 1), 0)
             n0 = np.random.binomial(self.shots, p0)
             expval = (n0 - (self.shots-n0)) / self.shots
 

--- a/pennylane_pq/devices.py
+++ b/pennylane_pq/devices.py
@@ -340,6 +340,10 @@ class ProjectQSimulator(_ProjectQDevice):
 
         if self.shots != 0 and expectation != 'Identity':
             p0 = (expval+1)/2
+            if p0 < 0:
+                p0 = 0
+            if p0 > 1:
+                p0 = 1
             n0 = np.random.binomial(self.shots, p0)
             expval = (n0 - (self.shots-n0)) / self.shots
 

--- a/pennylane_pq/devices.py
+++ b/pennylane_pq/devices.py
@@ -310,33 +310,31 @@ class ProjectQSimulator(_ProjectQDevice):
         super().reset()
 
     def pre_expval(self):
-        """Rotate qubits to the right basis before measurement, apply a measure all
-        operation and flush the device before retrieving expectation values.
+        """Flush the device before retrieving expectation values.
         """
-        if hasattr(self, 'expval_queue'): #we raise an except below in case there is no expval_queue but we are asked to measure in a basis different from PauliZ
-            for e in self.expval_queue:
-                if e.name == 'PauliX':
-                    self.apply('Hadamard', e.wires, list())
-                elif e.name == 'PauliY':
-                    self.apply('PauliZ', e.wires, list())
-                    self.apply('S', e.wires, list())
-                    self.apply('Hadamard', e.wires, list())
-                elif e.name == 'Hadamard':
-                    self.apply('RY', e.wires, [-np.pi/4])
-                elif e.name == 'Hermitian':
-                    raise NotImplementedError
-
-        self._eng.flush()
+        self._eng.flush(deallocate_qubits=False)
 
     def expval(self, expectation, wires, par):
         """Retrieve the requested expectation value.
         """
-        if expectation == 'Identity':
+        if expectation == 'PauliX' or expectation == 'PauliY' or expectation == 'PauliZ':
+            expval = self._eng.backend.get_expectation_value(
+                pq.ops.QubitOperator(str(expectation)[-1]+'0'),
+                [self._reg[wires[0]]])
+            # variance = 1 - expval**2
+        elif expectation == 'Hadamard':
+            expval = self._eng.backend.get_expectation_value(
+                1/np.sqrt(2)*pq.ops.QubitOperator('X0')+1/np.sqrt(2)*pq.ops.QubitOperator('Z0'),
+                [self._reg[wires[0]]])
+            # variance = 1 - expval**2
+        elif expectation == 'Identity':
             expval = 1
-        elif expectation != 'PauliZ' and not hasattr(self, 'expval_queue'):
-            raise DeviceError("Measurements in basis other than PauliZ are only supported when this plugin is used with versions of PennyLane that expose the expval_queue. Please update PennyLane and this plugin.")
-        else:
-            expval = self._eng.backend.get_probability([0], [self._reg[wires[0]]]) - self._eng.backend.get_probability([1], [self._reg[wires[0]]])
+            # variance = 1 - expval**2
+        # elif expectation == 'AllPauliZ':
+        #     expval = [self._eng.backend.get_expectation_value(
+        #         pq.ops.QubitOperator("Z"+'0'), [qubit])
+        #                for qubit in self._reg]
+        #     variance = [1 - e**2 for e in expval]
 
         if self.shots != 0 and expectation != 'Identity':
             p0 = (expval+1)/2


### PR DESCRIPTION
**Description of the Change:**
On multiple "shot" calls to the ProjectQ simulator, a small amount of float error can put the binomial distribution probability parameter slightly below 0 or slightly above 1, raising a breaking exception. This pull requests clamps potential small errors, such that probability is always exactly in the range [0, 1]. (This is necessary if using the [Qrack](https://github.com/vm6502q/qrack) simulator integration in ProjectQ, in particular.) When the potential error this PR addresses _does_ arise, it raises one or more exceptions in the existing plugin unit tests, but this issue is resolved by this PR itself.

**Benefits:**
By applying a clamp as appropriate, small numerical errors will not lead to breaking exceptions. Depending on system or ProjectQ fork differences, this is a much safer implementation, in general. It allows the use of the Qrack simulator integration fork, which supports GPU execution and/or reduced heap usage, for a simulator for ProjectQ.

**Possible Drawbacks:**
This could mask larger numerical problems in variants of ProjectQ. It adds a tiny bit of computational overhead.

**Related GitHub Issues:**
There are no related Github issues, at this time.