### PR TITLE
PennyLane v0.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
 env:
   - LOGGING=info
 install:
+  - pip install pip --upgrade
   - pip install -e git+https://github.com/XanaduAI/pennylane.git#egg=pennylane
   - pip install -r requirements.txt
   - pip install wheel pytest pytest-cov codecov --upgrade

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Features
 
 * Provides three devices to be used with PennyLane: ``projectq.simulator``, ``projectq.ibm``, and ``projectq.classical``. These provide access to the respective ProjectQ backends.
 
-* Supports a wide range of PennyLane operations and expectation values across the devices.
+* Supports a wide range of PennyLane operations and observables across the devices.
 
 * Combine ProjectQ high performance simulator and hardware backend support with PennyLane's automatic differentiation and optimization.
 

--- a/pennylane_pq/_version.py
+++ b/pennylane_pq/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = '0.2.1'
+__version__ = '0.4.0'

--- a/pennylane_pq/devices.py
+++ b/pennylane_pq/devices.py
@@ -123,8 +123,8 @@ class _ProjectQDevice(Device): #pylint: disable=abstract-method
     """
     name = 'ProjectQ PennyLane plugin'
     short_name = 'projectq'
-    pennylane_requires = '>=0.2.0'
-    version = '0.2.1'
+    pennylane_requires = '>=0.4.0'
+    version = '0.4.0'
     plugin_version = __version__
     author = 'Christian Gogolin'
     _capabilities = {'backend': list(["Simulator", "ClassicalSimulator", "IBMBackend"])}

--- a/pennylane_pq/devices.py
+++ b/pennylane_pq/devices.py
@@ -461,16 +461,16 @@ class ProjectQIBMBackend(_ProjectQDevice):
         operation and flush the device before retrieving expectation values.
         """
         if hasattr(self, 'obs_queue'): #we raise an except below in case there is no obs_queue but we are asked to measure in a basis different from PauliZ
-            for e in self.obs_queue:
-                if e.name == 'PauliX':
-                    self.apply('Hadamard', e.wires, list())
-                elif e.name == 'PauliY':
-                    self.apply('PauliZ', e.wires, list())
-                    self.apply('S', e.wires, list())
-                    self.apply('Hadamard', e.wires, list())
-                elif e.name == 'Hadamard':
-                    self.apply('RY', e.wires, [-np.pi/4])
-                elif e.name == 'Hermitian':
+            for obs in self.obs_queue:
+                if obs.name == 'PauliX':
+                    self.apply('Hadamard', obs.wires, list())
+                elif obs.name == 'PauliY':
+                    self.apply('PauliZ', obs.wires, list())
+                    self.apply('S', obs.wires, list())
+                    self.apply('Hadamard', obs.wires, list())
+                elif obs.name == 'Hadamard':
+                    self.apply('RY', obs.wires, [-np.pi/4])
+                elif obs.name == 'Hermitian':
                     raise NotImplementedError
 
         pq.ops.All(pq.ops.Measure) | self._reg #pylint: disable=expression-not-assigned

--- a/pennylane_pq/devices.py
+++ b/pennylane_pq/devices.py
@@ -345,6 +345,7 @@ class ProjectQSimulator(_ProjectQDevice):
         """
         expval = self.expval(observable, wires, par)
         variance = 1 - expval**2
+        # TODO: if this plugin supports non-involutory observables in future, may need to refactor this function
         return variance
 
 class ProjectQIBMBackend(_ProjectQDevice):
@@ -505,6 +506,7 @@ class ProjectQIBMBackend(_ProjectQDevice):
         """
         expval = self.expval(observable, wires, par)
         variance = 1 - expval**2
+        # TODO: if this plugin supports non-involutory observables in future, may need to refactor this function
         return variance
 
 
@@ -581,4 +583,5 @@ class ProjectQClassicalSimulator(_ProjectQDevice):
         """
         expval = self.expval(observable, wires, par)
         variance = 1 - expval**2
+        # TODO: if this plugin supports non-involutory observables in future, may need to refactor this function
         return variance

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 projectq
-pennylane
+pennylane>=0.4

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open("pennylane_pq/_version.py") as f:
 with open("requirements.txt") as f:
     requirements = [ #pylint: disable=invalid-name
         'projectq>=0.4.1',
-        'pennylane>=0.2'
+        'pennylane>=0.4'
     ]
 
 info = { #pylint: disable=invalid-name

--- a/tests/test_basis_state.py
+++ b/tests/test_basis_state.py
@@ -67,7 +67,7 @@ class BasisStateTest(BaseTest):
                 @qml.qnode(device)
                 def circuit():
                     qml.BasisState(bits_to_flip, wires=list(range(self.num_subsystems)))
-                    return qml.expval.PauliZ(0), qml.expval.PauliZ(1), qml.expval.PauliZ(2), qml.expval.PauliZ(3)
+                    return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1)), qml.expval(qml.PauliZ(2)), qml.expval(qml.PauliZ(3))
 
                 self.assertAllAlmostEqual([1]*self.num_subsystems-2*bits_to_flip, np.array(circuit()), delta=self.tol)
 
@@ -86,7 +86,7 @@ class BasisStateTest(BaseTest):
                 @qml.qnode(device)
                 def circuit():
                     qml.BasisState(bits_to_flip, wires=list(range(self.num_subsystems-1)))
-                    return qml.expval.PauliZ(0), qml.expval.PauliZ(1), qml.expval.PauliZ(2), qml.expval.PauliZ(3)
+                    return qml.expval(qml.PauliZ(0)), qml.expval(qml.PauliZ(1)), qml.expval(qml.PauliZ(2)), qml.expval(qml.PauliZ(3))
 
                 self.assertAllAlmostEqual([1]*(self.num_subsystems-1)-2*bits_to_flip, np.array(circuit()[:-1]), delta=self.tol)
 
@@ -100,7 +100,7 @@ class BasisStateTest(BaseTest):
             def circuit():
                 qml.PauliX(wires=[0])
                 qml.BasisState(np.array([0, 1, 0, 1]), wires=list(range(self.num_subsystems)))
-                return qml.expval.PauliZ(0)
+                return qml.expval(qml.PauliZ(0))
 
             self.assertRaises(pennylane._device.DeviceError, circuit)
 

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -126,8 +126,8 @@ class CompareWithDefaultQubitTest(BaseTest):
                         operation_wires = list(range(operation_class.num_wires)) if operation_class.num_wires > 1 else 0
                         observable_wires = list(range(observable_class.num_wires)) if observable_class.num_wires > 1 else 0
 
-                        operation_class(*operation_pars, operation_wires)
-                        return observable_class(*observable_pars, observable_wires)
+                        operation_class(*operation_pars, wires=operation_wires)
+                        return observable_class(*observable_pars, wires=observable_wires)
 
                     output = circuit()
                     if (operation, observable) not in outputs:

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -74,7 +74,7 @@ class CompareWithDefaultQubitTest(BaseTest):
 
             # run all single operation circuits
             for operation in dev.operations:
-                for observable in dev.expectations:
+                for observable in dev.observables:
                     log.info("Running device "+dev.short_name+" with a circuit consisting of a "+operation+" Operation followed by a "+observable+" Expectation")
 
                     @qml.qnode(dev)
@@ -83,8 +83,8 @@ class CompareWithDefaultQubitTest(BaseTest):
                             operation_class = getattr(qml, operation)
                         else:
                             operation_class = getattr(pennylane_pq, operation)
-                        if hasattr(qml.expval, observable):
-                            observable_class = getattr(qml.expval, observable)
+                        if hasattr(qml.ops, observable):
+                            observable_class = getattr(qml.ops, observable)
                         else:
                             observable_class = getattr(pennylane_pq.expval, observable)
 
@@ -127,7 +127,7 @@ class CompareWithDefaultQubitTest(BaseTest):
                         observable_wires = list(range(observable_class.num_wires)) if observable_class.num_wires > 1 else 0
 
                         operation_class(*operation_pars, wires=operation_wires)
-                        return observable_class(*observable_pars, wires=observable_wires)
+                        return qml.expval(observable_class(*observable_pars, wires=observable_wires))
 
                     output = circuit()
                     if (operation, observable) not in outputs:

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -57,23 +57,23 @@ class DocumentationTest(BaseTest):
         for dev in self.devices:
             docstring = dev.__doc__
             supp_operations = dev.operations
-            supp_expectations = dev.expectations
+            supp_observables = dev.observables
             #print(docstring)
             documented_operations = ([ re.findall(r"(?:pennylane\.|pennylane_pq.ops\.)([^`> ]*)", string) for string in re.findall(r"(?:(?:Extra|Supported PennyLane) Operations:\n((?:\s*:class:`[^`]+`,?\n)*))", docstring, re.MULTILINE)])
             documented_operations = set([item for sublist in documented_operations for item in sublist])
 
-            documented_expectations = ([ re.findall(r"(?:pennylane\.expval\.|pennylane_pq\.expval\.)([^`> ]*)", string) for string in re.findall(r"(?:(?:Extra|Supported PennyLane) Expectations:\n((?:\s*:class:`[^`]+`,?\n)*))", docstring, re.MULTILINE)])
-            documented_expectations = set([item for sublist in documented_expectations for item in sublist])
+            documented_observables = ([ re.findall(r"(?:pennylane\.|pennylane_pq\.)([^`> ]*)", string) for string in re.findall(r"(?:(?:Extra|Supported PennyLane) observables:\n((?:\s*:class:`[^`]+`,?\n)*))", docstring, re.MULTILINE)])
+            documented_observables = set([item for sublist in documented_observables for item in sublist])
 
             supported_but_not_documented_operations = supp_operations.difference(documented_operations)
             self.assertFalse(supported_but_not_documented_operations, msg="For device "+dev.short_name+" the Operations "+str(supported_but_not_documented_operations)+" are supported but not documented.")
             documented_but_not_supported_operations = documented_operations.difference(supp_operations)
             self.assertFalse(documented_but_not_supported_operations, msg="For device "+dev.short_name+" the Operations "+str(documented_but_not_supported_operations)+" are documented but not actually supported.")
 
-            supported_but_not_documented_expectations = supp_expectations.difference(documented_expectations)
-            self.assertFalse(supported_but_not_documented_expectations, msg="For device "+dev.short_name+" the Expectations "+str(supported_but_not_documented_expectations)+" are supported but not documented.")
-            documented_but_not_supported_expectations = documented_expectations.difference(supp_expectations)
-            self.assertFalse(documented_but_not_supported_expectations, msg="For device "+dev.short_name+" the Expectations "+str(documented_but_not_supported_expectations)+" are documented but not actually supported.")
+            supported_but_not_documented_observables = supp_observables.difference(documented_observables)
+            self.assertFalse(supported_but_not_documented_observables, msg="For device "+dev.short_name+" the Observables "+str(supported_but_not_documented_observables)+" are supported but not documented.")
+            documented_but_not_supported_observables = documented_observables.difference(supp_observables)
+            self.assertFalse(documented_but_not_supported_observables, msg="For device "+dev.short_name+" the Observables "+str(documented_but_not_supported_observables)+" are documented but not actually supported.")
 
 
 if __name__ == '__main__':

--- a/tests/test_ibm_expval_and_pre_expval_mock.py
+++ b/tests/test_ibm_expval_and_pre_expval_mock.py
@@ -31,12 +31,12 @@ from unittest.mock import patch, MagicMock, PropertyMock, call
 log.getLogger('defaults')
 
 class ExpvalAndPreExpvalMock(BaseTest):
-    """test pre_expval and expval of the plugin in a fake way that works without ibm credentials
+    """test pre_measure and expval of the plugin in a fake way that works without ibm credentials
     """
 
-    def test_pre_expval(self):
+    def test_pre_measure(self):
 
-        with patch('pennylane_pq.devices.ProjectQIBMBackend.expval_queue', new_callable=PropertyMock) as mock_expval_queue:
+        with patch('pennylane_pq.devices.ProjectQIBMBackend.obs_queue', new_callable=PropertyMock) as mock_obs_queue:
             mock_PauliX = MagicMock(wires=[0])
             mock_PauliX.name = 'PauliX'
             mock_PauliY = MagicMock(wires=[0])
@@ -46,7 +46,7 @@ class ExpvalAndPreExpvalMock(BaseTest):
             mock_Hermitian = MagicMock(wires=[0])
             mock_Hermitian.name = 'Hermitian'
 
-            mock_expval_queue.return_value = [
+            mock_obs_queue.return_value = [
                 mock_PauliX,
                 mock_PauliY,
                 mock_Hadamard,
@@ -56,7 +56,7 @@ class ExpvalAndPreExpvalMock(BaseTest):
             dev.apply = MagicMock()
 
             with patch('projectq.ops.All', new_callable=PropertyMock) as mock_All:
-                dev.pre_expval()
+                dev.pre_measure()
 
             dev._eng.assert_has_calls([call.flush()])
             # The following might have to be changed in case a more elegant/efficient/different
@@ -68,11 +68,11 @@ class ExpvalAndPreExpvalMock(BaseTest):
                                         call('RY', [0], [-0.7853981633974483])])
 
 
-            mock_expval_queue.return_value = [
+            mock_obs_queue.return_value = [
                 mock_Hermitian
             ]
             with patch('projectq.ops.All', new_callable=PropertyMock) as mock_All:
-                self.assertRaises(NotImplementedError, dev.pre_expval)
+                self.assertRaises(NotImplementedError, dev.pre_measure)
 
 
     def test_expval(self):
@@ -92,14 +92,14 @@ class Expval(BaseTest):
     """test expval()
     """
 
-    def test_expval_exception_if_no_expval_queue(self):
+    def test_expval_exception_if_no_obs_queue(self):
 
         if self.args.device == 'ibm' or self.args.device == 'all':
             dev = ProjectQIBMBackend(wires=2, shots=1, use_hardware=False, user='user', password='password', verbose=True)
         else:
             return
 
-        del dev.__dict__['_expval_queue']
+        del dev.__dict__['_obs_queue']
         dev._eng = MagicMock()
         dev._eng.backend = MagicMock()
         dev._eng.backend.get_probabilities = MagicMock()
@@ -110,7 +110,7 @@ class Expval(BaseTest):
         self.assertRaises(DeviceError, dev.expval, 'Hadamard', wires=[0], par=list())
 
 if __name__ == '__main__':
-    print('Testing PennyLane ProjectQ Plugin version ' + qml.version() + ', device expval and pre_expval.')
+    print('Testing PennyLane ProjectQ Plugin version ' + qml.version() + ', device expval and pre_measure.')
     # run the tests in this file
     suite = unittest.TestSuite()
     for t in (ExpvalAndPreExpvalMock, Expval):

--- a/tests/test_unsupported_operations.py
+++ b/tests/test_unsupported_operations.py
@@ -62,7 +62,7 @@ class UnsupportedOperationTest(BaseTest):
             @qml.qnode(device)
             def circuit():
                 qml.Beamsplitter(0.2, 0.1, wires=[0,1]) #this expectation will never be supported
-                return qml.expval.Homodyne(0.7, 0)
+                return qml.expval(qml.Homodyne(0.7, 0))
 
             self.assertRaises(pennylane._device.DeviceError, circuit)
 
@@ -74,7 +74,7 @@ class UnsupportedOperationTest(BaseTest):
         for device in self.devices:
             @qml.qnode(device)
             def circuit():
-                return qml.expval.Homodyne(0.7, 0) #this expectation will never be supported
+                return qml.expval(qml.Homodyne(0.7, 0)) #this expectation will never be supported
 
             self.assertRaises(pennylane._device.DeviceError, circuit)
 

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -1,0 +1,102 @@
+# Copyright 2018 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for variance
+"""
+from unittest.mock import MagicMock
+import pytest
+
+import numpy as np
+import pennylane
+
+from defaults import TOLERANCE
+from pennylane_pq.devices import ProjectQSimulator, ProjectQClassicalSimulator, ProjectQIBMBackend
+
+
+@pytest.fixture
+def tol():
+    """Numerical tolerance"""
+    return TOLERANCE
+
+
+@pytest.fixture
+def dev(DevClass, monkeypatch):
+    """devices"""
+    if issubclass(DevClass, ProjectQSimulator):
+        yield DevClass(wires=1, shots=20000000, verbose=True)
+
+    elif issubclass(DevClass, ProjectQClassicalSimulator):
+        yield DevClass(wires=1, verbose=True)
+
+    elif issubclass(DevClass, ProjectQIBMBackend):
+        ibm_options = pennylane.default_config["projectq.ibm"]
+        init_device = DevClass(
+            wires=1,
+            use_hardware=False,
+            num_runs=8 * 1024,
+            user="user",
+            password="password",
+            verbose=True,
+        )
+
+        with monkeypatch.context() as m:
+            m.setattr(
+                "pennylane_pq.devices.ProjectQIBMBackend.obs_queue",
+                [pennylane.PauliZ(wires=0, do_queue=False)],
+            )
+            init_device._eng = MagicMock()
+            init_device._eng.backend = MagicMock()
+            init_device._eng.backend.get_probabilities = MagicMock()
+            yield init_device
+
+
+@pytest.mark.parametrize(
+    "DevClass", [ProjectQSimulator, ProjectQClassicalSimulator, ProjectQIBMBackend]
+)
+def test_var_pauliz(dev, tol):
+    """Test that variance of PauliZ is the same as I-<Z>^2"""
+    dev.apply("PauliX", wires=[0], par=[])
+
+    if isinstance(dev, ProjectQIBMBackend):
+        dev._eng.backend.get_probabilities.return_value = {"0": 0, "1": 1}
+
+    dev.pre_measure()
+    var = dev.var("PauliZ", [0], [])
+    mean = dev.expval("PauliZ", [0], [])
+    dev.post_measure()
+
+    assert np.allclose(var, 1 - mean ** 2, atol=tol, rtol=0)
+
+
+@pytest.mark.parametrize("DevClass", [ProjectQSimulator, ProjectQIBMBackend])
+def test_var_pauliz_rotated_state(dev, tol):
+    """test correct variance for <Z> of a rotated state"""
+    phi = 0.543
+    theta = 0.6543
+
+    dev.apply("RX", wires=[0], par=[phi])
+    dev.apply("RY", wires=[0], par=[theta])
+
+    if isinstance(dev, ProjectQIBMBackend):
+        dev._eng.backend.get_probabilities.return_value = {
+            "0": 0.5 * (1 + np.cos(theta) * np.cos(phi)),
+            "1": 0.5 * (1 - np.cos(theta) * np.cos(phi)),
+        }
+
+    dev.pre_measure()
+    var = dev.var("PauliZ", [0], [])
+    dev.post_measure()
+    expected = 0.25 * (3 - np.cos(2 * theta) - 2 * np.cos(theta) ** 2 * np.cos(2 * phi))
+
+    assert np.allclose(var, expected, atol=tol, rtol=0)

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -72,8 +72,8 @@ def test_var_pauliz(dev, tol):
         dev._eng.backend.get_probabilities.return_value = {"0": 0, "1": 1}
 
     dev.pre_measure()
-    var = dev.var("PauliZ", [0], [])
-    mean = dev.expval("PauliZ", [0], [])
+    var = dev.var("PauliZ", wires=[0], par=[])
+    mean = dev.expval("PauliZ", wires=[0], par=[])
     dev.post_measure()
 
     assert np.allclose(var, 1 - mean ** 2, atol=tol, rtol=0)
@@ -95,7 +95,7 @@ def test_var_pauliz_rotated_state(dev, tol):
         }
 
     dev.pre_measure()
-    var = dev.var("PauliZ", [0], [])
+    var = dev.var("PauliZ", wires=[0], par=[])
     dev.post_measure()
     expected = 0.25 * (3 - np.cos(2 * theta) - 2 * np.cos(theta) ** 2 * np.cos(2 * phi))
 


### PR DESCRIPTION
Updating the plugin to work with PL version 0.4. Changes include:

* Adds support for PennyLane version 0.4. This includes:

  - Renaming `expectation` -> `observable` in various places in the documentation
  - `Device.expectations` -> `Device.observables`
  - `Device.pre_expval` -> `Device.pre_measure`
  - `Device.post_expval` -> `Device.post_measure`

* Adds the device method `var()` to all devices

* Adds corresponding tests, to ensure the variance is correctly calculated.

* Updates the minimum required PennyLane version to 0.4

* Update the documentation to reflect PennyLane v0.4 support

* Increment plugin version number to 0.4.0

Once this PR is merged, I will update the PyPI release.