### PR TITLE
Remove opening of requirements.txt from setup.py

### DIFF
--- a/pennylane_pq/_version.py
+++ b/pennylane_pq/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = '0.4.0'
+__version__ = '0.5.0-dev'

--- a/setup.py
+++ b/setup.py
@@ -16,44 +16,34 @@
 from setuptools import setup
 
 with open("pennylane_pq/_version.py") as f:
-    version = f.readlines()[-1].split()[-1].strip("\"'") #pylint: disable=invalid-name
+    version = f.readlines()[-1].split()[-1].strip("\"'")  # pylint: disable=invalid-name
 
 
-with open("requirements.txt") as f:
-    requirements = [ #pylint: disable=invalid-name
-        'projectq>=0.4.1',
-        'pennylane>=0.4'
-    ]
+requirements = ["projectq>=0.4.1", "pennylane>=0.4"]  # pylint: disable=invalid-name
 
-info = { #pylint: disable=invalid-name
-    'name': 'PennyLane-PQ',
-    'version': version,
-    'maintainer': 'Xanadu Inc.',
-    'maintainer_email': 'christiangogolin@xanadu.ai',
-    'url': 'http://xanadu.ai',
-    'license': 'Apache License 2.0',
-    'packages': [
-        'pennylane_pq'
-    ],
-    'entry_points': {
-        'pennylane.plugins': [
-            'projectq.simulator = pennylane_pq:ProjectQSimulator',
-            'projectq.classical = pennylane_pq:ProjectQClassicalSimulator',
-            'projectq.ibm = pennylane_pq:ProjectQIBMBackend',
-            ],
-        },
-    'description': 'PennyLane plugin for ProjectQ',
-    'long_description': open('README.rst').read(),
-    'provides': ["pennylane_pq"],
-    'install_requires': requirements,
-    # 'extras_require': extra_requirements,
-    'command_options': {
-        'build_sphinx': {
-            'version': ('setup.py', version),
-            'release': ('setup.py', version)}}
+
+info = {  # pylint: disable=invalid-name
+    "name": "PennyLane-PQ",
+    "version": version,
+    "maintainer": "Xanadu Inc.",
+    "maintainer_email": "christiangogolin@xanadu.ai",
+    "url": "http://xanadu.ai",
+    "license": "Apache License 2.0",
+    "packages": ["pennylane_pq"],
+    "entry_points": {
+        "pennylane.plugins": [
+            "projectq.simulator = pennylane_pq:ProjectQSimulator",
+            "projectq.classical = pennylane_pq:ProjectQClassicalSimulator",
+            "projectq.ibm = pennylane_pq:ProjectQIBMBackend",
+        ]
+    },
+    "description": "PennyLane plugin for ProjectQ",
+    "long_description": open("README.rst").read(),
+    "provides": ["pennylane_pq"],
+    "install_requires": requirements,
 }
 
-classifiers = [ #pylint: disable=invalid-name
+classifiers = [  # pylint: disable=invalid-name
     "Development Status :: 4 - Beta",
     "Environment :: Console",
     "Intended Audience :: Science/Research",
@@ -64,12 +54,12 @@ classifiers = [ #pylint: disable=invalid-name
     "Operating System :: POSIX :: Linux",
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python",
-    'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.5',
-    'Programming Language :: Python :: 3.6',
-    'Programming Language :: Python :: 3.7',
-    'Programming Language :: Python :: 3 :: Only',
-    "Topic :: Scientific/Engineering :: Physics"
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.5",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: Scientific/Engineering :: Physics",
 ]
 
 setup(classifiers=classifiers, **(info))

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -132,7 +132,6 @@ class CompareWithDefaultQubitTest(BaseTest):
                         operation_class(*operation_pars, wires=operation_wires)
                         return qml.expval(observable_class(*observable_pars, wires=observable_wires))
 
-                    print("here")
                     output = circuit()
                     if (operation, observable) not in outputs:
                         outputs[(operation, observable)] = {}

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -123,8 +123,8 @@ class CompareWithDefaultQubitTest(BaseTest):
                             observable_pars = {}
 
                         # apply to the first wires
-                        operation_wires = list(range(operation_class.num_wires)) if operation_class.num_wires > 1 else 0
-                        observable_wires = list(range(observable_class.num_wires)) if observable_class.num_wires > 1 else 0
+                        operation_wires = list(range(operation_class.num_wires)) if operation_class.num_wires > 1 or operation_class.num_wires <= 0 else 0
+                        observable_wires = list(range(observable_class.num_wires)) if observable_class.num_wires > 1 or observable_class.num_wires <= 0 else 0
 
                         operation_class(*operation_pars, wires=operation_wires)
                         return qml.expval(observable_class(*observable_pars, wires=observable_wires))

--- a/tests/test_compare_with_default_qubit.py
+++ b/tests/test_compare_with_default_qubit.py
@@ -123,12 +123,16 @@ class CompareWithDefaultQubitTest(BaseTest):
                             observable_pars = {}
 
                         # apply to the first wires
-                        operation_wires = list(range(operation_class.num_wires)) if operation_class.num_wires > 1 or operation_class.num_wires <= 0 else 0
-                        observable_wires = list(range(observable_class.num_wires)) if observable_class.num_wires > 1 or observable_class.num_wires <= 0 else 0
+                        operation_wires = list(range(operation_class.num_wires)) if operation_class.num_wires > 1 else 0
+                        observable_wires = list(range(observable_class.num_wires)) if observable_class.num_wires > 1 else 0
+
+                        if str(operation) == "QubitStateVector":
+                            operation_wires = range(self.num_subsystems)
 
                         operation_class(*operation_pars, wires=operation_wires)
                         return qml.expval(observable_class(*observable_pars, wires=observable_wires))
 
+                    print("here")
                     output = circuit()
                     if (operation, observable) not in outputs:
                         outputs[(operation, observable)] = {}

--- a/tests/test_unsupported_operations.py
+++ b/tests/test_unsupported_operations.py
@@ -62,7 +62,7 @@ class UnsupportedOperationTest(BaseTest):
             @qml.qnode(device)
             def circuit():
                 qml.Beamsplitter(0.2, 0.1, wires=[0,1]) #this expectation will never be supported
-                return qml.expval(qml.Homodyne(0.7, 0))
+                return qml.expval(qml.QuadOperator(0.7, 0))
 
             self.assertRaises(pennylane._device.DeviceError, circuit)
 
@@ -74,7 +74,7 @@ class UnsupportedOperationTest(BaseTest):
         for device in self.devices:
             @qml.qnode(device)
             def circuit():
-                return qml.expval(qml.Homodyne(0.7, 0)) #this expectation will never be supported
+                return qml.expval(qml.QuadOperator(0.7, 0)) #this expectation will never be supported
 
             self.assertRaises(pennylane._device.DeviceError, circuit)
 


### PR DESCRIPTION
**Description of the Change:** Remove opening of requirements.txt from setup.py

**Benefits:** Avoids `FileNotFoundError`, as Python renames this file during packaging to `requires.txt`

**Possible Drawbacks:** n/a

**Related GitHub Issues:** #52 
