### PR TITLE
Introducing 'qubit' as a model in the capabilities dictionary

### DIFF
--- a/pennylane_pq/devices.py
+++ b/pennylane_pq/devices.py
@@ -130,7 +130,7 @@ class _ProjectQDevice(Device): #pylint: disable=abstract-method
     version = '0.4.2'
     plugin_version = __version__
     author = 'Christian Gogolin'
-    _capabilities = {'backend': list(["Simulator", "ClassicalSimulator", "IBMBackend"])}
+    _capabilities = {'backend': list(["Simulator", "ClassicalSimulator", "IBMBackend"]), 'model': 'qubit'}
 
     @abc.abstractproperty
     def _operation_map(self):

--- a/tests/test_unsupported_operations.py
+++ b/tests/test_unsupported_operations.py
@@ -58,11 +58,16 @@ class UnsupportedOperationTest(BaseTest):
             return
         self.logTestName()
 
+        class SomeOperation(qml.operation.Operation):
+            num_params = 0
+            num_wires = 1
+            par_domain = 'A'
+
         for device in self.devices:
             @qml.qnode(device)
             def circuit():
-                qml.Beamsplitter(0.2, 0.1, wires=[0,1]) #this expectation will never be supported
-                return qml.expval(qml.QuadOperator(0.7, 0))
+                SomeOperation(wires=0)
+                return qml.expval(qml.PauliZ(0))
 
             self.assertRaises(pennylane._device.DeviceError, circuit)
 
@@ -71,10 +76,15 @@ class UnsupportedOperationTest(BaseTest):
             return
         self.logTestName()
 
+        class SomeObservable(qml.operation.Observable):
+            num_params = 0
+            num_wires = 1
+            par_domain = 'A'
+
         for device in self.devices:
             @qml.qnode(device)
             def circuit():
-                return qml.expval(qml.QuadOperator(0.7, 0)) #this expectation will never be supported
+                return qml.expval(SomeObservable(wires=0)) #this expectation will never be supported
 
             self.assertRaises(pennylane._device.DeviceError, circuit)
 


### PR DESCRIPTION
**Description of the Change:**
Adding the `'model': 'qubit'` entry into the ``capabilities`` dictionary. Adjusting tests that previously used ``CV`` operators to use custom created operators.

**Benefits:**
Now ``_ProjectQDevice`` can act as a qubit device while using PL core. This fixed several tests.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A